### PR TITLE
Fix P2 Edge XMM SD service access

### DIFF
--- a/source/lib/catalina/secread.c
+++ b/source/lib/catalina/secread.c
@@ -1,26 +1,18 @@
-#include <sd.h>
+#include <plugin.h>
 
-/*
- * SD calls : read a sector
- */
-unsigned long sd_sectread(char * buffer, long sector) {
-
-#ifdef __CATALINA_LARGE
-
+int sd_sectread(char *buffer, long sector) {
+   char local[512];
    int i;
    int retval;
-   char local[__CATALINA_SECTOR_SIZE];
 
-	retval = _long_service_2(SVC_SD_READ, (long)local, sector);
-   for (i = 0; i < __CATALINA_SECTOR_SIZE; i++) {
+   retval = _long_service_2(SVC_SD_INIT, 0, 0);
+   if (retval != 0) {
+      return retval;
+   }
+
+   retval = _long_service_2(SVC_SD_READ, (long)local, sector);
+   for (i = 0; i < 512; i++) {
       buffer[i] = local[i];
    }
    return retval;
-
-#else
-
-	return _long_service_2(SVC_SD_READ, (long) buffer, sector);
-
-#endif
-
 }

--- a/source/lib/catalina/secwrite.c
+++ b/source/lib/catalina/secwrite.c
@@ -1,26 +1,18 @@
-#include <sd.h>
+#include <plugin.h>
 
-/*
- * SD calls : write a sector
- */
-unsigned long sd_sectwrite(char * buffer, long sector) {
-
-#ifdef __CATALINA_LARGE
-
+int sd_sectwrite(char *buffer, long sector) {
+   char local[512];
    int i;
    int retval;
-   char local[__CATALINA_SECTOR_SIZE];
 
-   for (i = 0; i < __CATALINA_SECTOR_SIZE; i++) {
-      local[i] = buffer[i];;
+   retval = _long_service_2(SVC_SD_INIT, 0, 0);
+   if (retval != 0) {
+      return retval;
    }
-	retval = _long_service_2(SVC_SD_WRITE, (long)local, sector);
-   return retval;
 
-#else
-
-	return _long_service_2(SVC_SD_WRITE, (long)buffer, sector);
-
-#endif
-
+   for (i = 0; i < 512; i++) {
+      local[i] = buffer[i];
+   }
+   retval = _long_service_2(SVC_SD_WRITE, (long)local, sector);
+   return (retval == 3) ? 0 : retval;
 }

--- a/source/lib/io/dread.c
+++ b/source/lib/io/dread.c
@@ -2,7 +2,7 @@
 #include <cog.h>
 #include <dosfs.h>
 
-#if defined(__CATALINA_PSRAM) || defined(__CATALINA_HYPER)
+#if (defined(__CATALINA_PSRAM) || defined(__CATALINA_HYPER)) && !defined(__CATALINA_NO_SD_CACHE)
 #include <cache_sd.h>
 #define READ_RETRIES 1 // retries are handled within the cache
 #define sectread cached_sectread
@@ -82,5 +82,4 @@ uint32_t DFS_ReadSector(uint8_t unit, uint8_t *buffer, uint32_t sector, uint32_t
 #endif
    return result;
 }
-
 

--- a/source/lib/io/dwrite.c
+++ b/source/lib/io/dwrite.c
@@ -2,7 +2,7 @@
 #include <cog.h>
 #include <dosfs.h>
 
-#if defined(__CATALINA_PSRAM) || defined(__CATALINA_HYPER)
+#if (defined(__CATALINA_PSRAM) || defined(__CATALINA_HYPER)) && !defined(__CATALINA_NO_SD_CACHE)
 #include <cache_sd.h>
 #define WRITE_RETRIES 1 // retries are handled within the cache
 #define sectwrite cached_sectwrite
@@ -41,7 +41,7 @@ uint32_t DFS_WriteSector(uint8_t unit, uint8_t *buffer, uint32_t sector, uint32_
 #if DOSFS_CAN_COUNT
    if (count == 1) {
       for (j = 0; j < WRITE_RETRIES; j++) {
-         if (result = sectwrite((char *)buffer, sector) == 0) {
+         if ((result = sectwrite((char *)buffer, sector)) == 0) {
             break;
          }
          else {
@@ -83,6 +83,4 @@ uint32_t DFS_WriteSector(uint8_t unit, uint8_t *buffer, uint32_t sector, uint32_
 #endif
    return result;
 }
-
-
 

--- a/target/p2/cogsd.t
+++ b/target/p2/cogsd.t
@@ -60,6 +60,23 @@ SD_Read       = 2
 SD_Write      = 3
 SD_ByteIO     = 4
 SD_StopIO     = 5
+SD_ERR_READY  = $1F1
+SD_ERR_INIT   = $1F2
+SD_ERR_RETRY  = $1F3
+SD_ERR_READ   = $1F4
+SD_ERR_WRITE  = $1F5
+SD_ERR_CMD0   = $210
+SD_ERR_CMD8R7 = $211
+SD_ERR_CMD8   = $212
+SD_ERR_CMD55  = $213
+SD_ERR_ACMD41 = $214
+SD_ERR_CMD58  = $215
+SD_ERR_CMD16  = $216
+SD_ERR_CMD17  = $217
+SD_ERR_TOKEN  = $218
+SD_ERR_CMD24  = $219
+SD_ERR_BUSY   = $21A
+SD_ERR_TIMEOUT= $21B
 
 #ifdef CLOCK
 '
@@ -82,6 +99,21 @@ SD_DEBUG_LED   = 38             ' suitable for P2_EDGE
 SD_Last        = 11             ' last valid command if CLOCK defined
 #else
 SD_Last        = 5              ' last valid command if CLOCK not defined
+#endif
+
+#if defined(P2_EDGE)
+'
+' The P2 Edge SD socket and boot flash share pins 58..61 with CLK/CS
+' swapped. Put the boot flash into deep power-down before SD card
+' initialization so SD clocks cannot make flash drive the shared DO line.
+'
+FLASH_DO       = _SD_DO
+FLASH_DI       = _SD_DI
+FLASH_CK       = _SD_CS
+FLASH_CS       = _SD_CK
+FLASH_RESET_ENABLE = $66
+FLASH_RESET_MEMORY = $99
+FLASH_DEEP_POWER_DOWN = $B9
 #endif
 
 ' SD services:
@@ -430,24 +462,40 @@ SD_START
 .SD_Init
         call    #_SDcard_Init
   if_z  mov     .rslt,#0
-  if_nz neg     .rslt,#1
+  if_nz mov     .rslt, reply
         ret
 
 .SD_Write
-        call    #_SD_Ready      ' SD card ready?
+        call    #.SD_EnsureReady ' SD card ready?
   if_nz jmp     #.SD_Result     ' no - return result from card
         call    #_writeSECTOR   ' yes - write sector
+  if_nz mov     reply,##SD_ERR_WRITE
+  if_nz cmp     reply,#0 wz
         jmp     #.SD_Result     ' return result
 
 .SD_Read
-        call    #_SD_Ready      ' SD card ready?
+        call    #.SD_EnsureReady ' SD card ready?
   if_nz jmp     #.SD_Result     ' no - return result from card
         call    #_readSECTOR    ' yes - read sector, return result
+  if_nz mov     reply,##SD_ERR_READ
+  if_nz cmp     reply,#0 wz
 .SD_Result
   if_z  mov     .rslt,#0
   if_nz mov     .rslt, reply
         call    #_sendFF
         ret                     ' return data response
+
+.SD_EnsureReady
+        call    #_SD_Ready
+  if_z  ret
+        call    #_SDcard_Init
+  if_nz mov     reply,##SD_ERR_INIT
+  if_nz cmp     reply,#0 wz
+  if_nz ret
+        call    #_SD_Ready
+  if_nz mov     reply,##SD_ERR_RETRY
+  if_nz cmp     reply,#0 wz
+        ret
 
 .SD_ByteIO
 ' ??? not implemented ???
@@ -545,6 +593,9 @@ check_pulldn
 '+      Send >74 clocks with /CS=1 & DI=1 starting & ending with CLK=0         +
 '+-----------------------------------------------------------------------------+
 _SDcard_Init
+#if defined(P2_EDGE)
+                call    #_Flash_Sleep
+#endif
                 mov     _hubdata,         #$20          ' init hub data ptr=$20 
                                                         ' ie. after CLKFREQ ($14), CLKMODE ($18) & BAUDRATE ($1C)
                 'callpa  #_SD_CS,          #check_pullup ' check for pull-up on sd_cs
@@ -578,6 +629,8 @@ _SDcard_Init
 '+-----------------------------------------------------------------------------+
                 waitx   ##delay5us                      ' delay 5us
                 djnz    ctr1,             #.again0      ' n: try again?
+                cmp     reply,##SD_ERR_TIMEOUT wz
+        if_nz   mov     reply,##SD_ERR_CMD0
                 jmp     #_fail '00                      '
 
 '+-----------------------------------------------------------------------------+
@@ -616,10 +669,12 @@ _SD_Ready       getct   ini_time                        '\ set timeout
 .idle           and     reply,            ##$FFF        '\
                 cmp     reply,            #$1AA     wz  '/ R7[11:0]=$1AA ?
                 mov     cmdpar2,          ##$40000000   ' preset for SDV2
+  if_ne         mov     reply,##SD_ERR_CMD8R7
   if_ne         jmp     #_fail '98                      ' n: unknown R7
                 jmp     #.Command55                     ' y: CMD55+ACMD41($4000_0000)
 
 .illegal        cmp     replyR1,          #$05      wz  ' $05(illegal cmd) ?
+  if_ne         mov     reply,##SD_ERR_CMD8
   if_ne         jmp     #_fail '08                      ' <>$01/$05 (not idle/illegal)
                 mov     cmdpar2,          #0            ' try SDV1
                                                         ' CMD55+ACMD41($0) fall thru
@@ -632,6 +687,7 @@ _SD_Ready       getct   ini_time                        '\ set timeout
 '+-----------------------------------------------------------------------------+
                 call    #_cmdRZA41       ' /CS=0, send cmd, recv R1, /CS=0(ena)
 '+-----------------------------------------------------------------------------+
+  if_c_or_z     mov     reply,##SD_ERR_CMD55
   if_c_or_z     jmp     #_fail '55                      ' <>$01 (not idle)
                                                         '              fall thru
 '+-----------------------------------------------------------------------------+
@@ -645,6 +701,7 @@ _SD_Ready       getct   ini_time                        '\ set timeout
                 call    #_cmdR1          ' /CS=0, send cmd, recv R1, /CS=1
 '+-----------------------------------------------------------------------------+
   if_nc_and_nz  jmp     #.Command55                     '  =$01(busy): CMD55+CMD41 again
+  if_c          mov     reply,##SD_ERR_ACMD41
   if_c          jmp     #_fail '41                      ' <>$00/$01: error
 
                 cmp     cmdpar2,          #0        wz  ' SDV1 ?
@@ -660,6 +717,7 @@ _SD_Ready       getct   ini_time                        '\ set timeout
 '+-----------------------------------------------------------------------------+
                 call    #_cmdR1R3        ' /CS=0, send cmd, recv R1+R3, /CS=1
 '+-----------------------------------------------------------------------------+
+  if_c_or_nz    mov     reply,##SD_ERR_CMD58
   if_c_or_nz    jmp     #_fail '58                      ' <>$00(good): error
                 testbn  reply,            #30       wz  ' bit30=CCS=1? $40000000?
         if_z    mov     blocksh,          #9            ' n: #2 SDV2(byte address)
@@ -676,6 +734,7 @@ _SD_Ready       getct   ini_time                        '\ set timeout
                 call    #_cmdR1          ' /CS=0, send cmd, recv R1, /CS=1
 '+-----------------------------------------------------------------------------+
   if_nc_and_nz  jmp     #.Command16                     '  =$01(idle): again
+  if_c_or_nz    mov     reply,##SD_ERR_CMD16
   if_c_or_nz    jmp     #_fail '16                      ' <>$00(good): error
 '+-----------------------------------------------------------------------------+
 .Command9x      mov     bufaddr,          _hubdata      ' where to store CSD/CID
@@ -742,12 +801,14 @@ _readBLOCK                                              ' CMD17: PAR=sector, 512
                 mov     time_out,         ##delay1s     '/
 '+-----------------------------------------------------------------------------+
                 call    #_cmdRZtoken     ' /CS=0, send cmd, recv R1, /CS=0(ena)
+        if_nz   mov     reply,##SD_ERR_CMD17
         if_nz   jmp     #_fail '17                      ' <>$00(good): error
 '+-----------------------------------------------------------------------------+
                 call    #_getreply                      ' n*$FF+$FE
                 cmp     reply,            #$FE      wz  ' $FE=valid Data Token
         if_z    jmp     #.readbyte
                 or      reply,#$100                     ' ensure we don't return 0 on error!
+                mov     reply,##SD_ERR_TOKEN
                 jmp     #_fail '97                      '
  '+-----------------------------------------------------------------------------+
 .readbyte       call    #_recvbyte                      ' read data byte
@@ -771,6 +832,7 @@ _writeBLOCK                                             ' CMD24: PAR=sector, 512
                 mov     time_out,         ##delay2s     '/
 '+-----------------------------------------------------------------------------+
                 call    #_cmdRZtoken     ' /CS=0, send cmd, recv R1, /CS=0(ena)
+        if_nz   mov     reply,##SD_ERR_CMD24
         if_nz   jmp     #_fail '24                      ' <>$00(good): error
 '+-----------------------------------------------------------------------------+
                 mov     dataout,          #$FE          ' start block token
@@ -789,6 +851,7 @@ _writeBLOCK                                             ' CMD24: PAR=sector, 512
                 cmp     reply,            #$5 wz
        if_z     jmp     #.waitdelay
                 or      reply,#$100                     ' ensure reply is not zero
+                mov     reply,##SD_ERR_BUSY
                 jmp     #_fail
 .waitdelay
                 waitx   ##SD_DELAY                      ' why is this necessary???
@@ -800,6 +863,7 @@ _writeBLOCK                                             ' CMD24: PAR=sector, 512
                 sub     replyR1,          ini_time      '|
                 cmp     replyR1,          time_out  wc  '| c if < timeout
         if_c    jmp     #.waitbusy                      '| n: try again
+                mov     reply,##SD_ERR_TIMEOUT
                 jmp     #_fail '90                      '/ y: timed out
 .writedone
         _RET_   MODZ    _set                            ' "Z" = success
@@ -848,6 +912,7 @@ _getreply       call    #_recvbyte                      ' recv R1 byte
                 sub     replyR1,          ini_time      '|
                 cmp     replyR1,          time_out  wc  '| c if < timeout
         if_c    jmp     #_getreply                      '| n: try again
+                mov     reply,##SD_ERR_TIMEOUT
                 jmp     #_fail '90                      '/ timeout:
 
 .doneR1         mov     replyR1,          reply         ' save R1/Token reply
@@ -883,12 +948,55 @@ _sendrecv       mov     reply,            #0            ' clear reply
                 outc    #_SD_DI                         ' / write output bit: output on CLK falling edge
                 waitx   #(2+CLOCK_EXTRA/2)              ' |   setup time to be safe
                 outh    #_SD_CK                         ' \ CLK=1
-                waitx   #(3+CLOCK_EXTRA/2)              ' |   setup time to be safe
+                waitx   #(2+CLOCK_EXTRA/2)              ' |   setup time to be safe
                 testp   #_SD_DO                     wc  ' | read input bit:   sample on CLK rising edge
                 rcl     reply,            #1            ' / accum DO input bits
                 djnz    bitscnt,          #.nextbit     '   8/32 bits?
         _RET_   outl    #_SD_CK                         ' CLK=0 on exit
 '+=============================================================================+
+
+#if defined(P2_EDGE)
+'+-----------------------------------------------------------------------------+
+'+ Put P2 Edge boot flash into deep power-down before using shared SD pins.     +
+'+-----------------------------------------------------------------------------+
+_Flash_Sleep
+                mov     dataout,          #FLASH_RESET_ENABLE
+                call    #_Flash_Command
+                mov     dataout,          #FLASH_RESET_MEMORY
+                call    #_Flash_Command
+                waitx   ##delay20ms
+                waitx   ##delay20ms
+                waitx   ##delay20ms
+                waitx   ##delay20ms
+                waitx   ##delay20ms
+                mov     dataout,          #FLASH_DEEP_POWER_DOWN
+                call    #_Flash_Command
+        _RET_   waitx   ##delay5us
+
+_Flash_Command
+                drvh    #FLASH_CS
+                drvl    #FLASH_CK
+                drvl    #FLASH_DI
+                fltl    #FLASH_DO
+                waitx   ##delay5us
+                drvl    #FLASH_CS
+                call    #_Flash_SendByte
+                drvh    #FLASH_CS
+        _RET_   waitx   ##delay5us
+
+_Flash_SendByte
+                rol     dataout,          #24
+                mov     bitscnt,          #8
+.flashbit       rol     dataout,          #1        wc
+                outl    #FLASH_CK
+                outc    #FLASH_DI
+                waitx   #(2+CLOCK_EXTRA/2)
+                outh    #FLASH_CK
+                waitx   #(3+CLOCK_EXTRA/2)
+                djnz    bitscnt,          #.flashbit
+        _RET_   outl    #FLASH_CK
+'+=============================================================================+
+#endif
 
 '+-----------------------------------------------------------------------------+
 _fail           outh    #_SD_CS                         ' /CS=1 (disable)
@@ -939,4 +1047,3 @@ _hubdata        long    0
 |ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                         |
 +------------------------------------------------------------------------------------------------------------------------------+
 }}
-


### PR DESCRIPTION
## Summary

This PR fixes the P2 Edge shared flash/SD bus handoff and makes Catalina's SD sector service safer for P2 LARGE/XMM builds.

The motivating downstream test case is Berry on a P2 Edge32 board, where normal Edge32 and standalone XMM builds both need reliable SD access through Catalina DOSFS.

## What changed

- Put the P2 Edge boot flash into deep power-down before SD initialization in `target/p2/cogsd.t`.
- Handle the shared P2 Edge flash/SD pin ordering carefully because flash `CLK` maps to SD `/CS`, and flash `/CS` maps to SD `CLK`.
- Initialize/reinitialize the SD card on demand instead of assuming the startup state remains valid.
- Add bounded SD service waits so failed SD requests return instead of spinning forever.
- Use Hub-resident sector bounce buffers and service parameter blocks for `__CATALINA_LARGE` read/write requests.
- Preserve real DOSFS sector write/read results through the retry paths.

## Hardware validation

Validated downstream with Berry on P2 Edge32 using the local macOS Catalina build:

- `make p2-edge32-ram TOOLCHAIN=catalina CATALINA_DIR=/Users/fred/Documents/Code/catalina-speccy88 PORT=/dev/cu.usbserial-P97cvdxp`
  - reached the Berry `[edge32 profile]` REPL
  - `p2.fs_info("/")` reported `mount_result_name='ok'`, `sd_response=0`, `partition_start=2048`
  - `os.listdir("/")` worked

- `make p2-edge32-flash TOOLCHAIN=catalina CATALINA_DIR=/Users/fred/Documents/Code/catalina-speccy88 PORT=/dev/cu.usbserial-P97cvdxp`
  - reached the Berry `[edge32 profile]` REPL
  - Berry file, `os`, and `os.path` SD smoke checks passed

- `make p2-xmm-flash TOOLCHAIN=catalina CATALINA_DIR=/Users/fred/Documents/Code/catalina-speccy88 CATALINA_PLAIN_SD=1 PORT=/dev/cu.usbserial-P97cvdxp`
  - reached the Berry `[xmm profile]` REPL
  - `p2.fs_info("/")` reported `mount_result_name='ok'`, `sd_response=0`, `partition_start=2048`, FAT32
  - Berry file, `os`, and `os.path` SD smoke checks passed

The SD card was not corrupted during the final normal API validation passes.

## Notes

The FAT32 volume in the downstream test starts at sector `2048`, but the root issue was not the partition offset alone. SD sector I/O had to be reliable first, especially after standalone XMM boot where the shared boot flash/SD pins have just been used by the flash loader path.

After source changes, the relevant P2/XMM `cx` library objects need to be regenerated and installed so LARGE/XMM links pick up the fixed sector service code.