### PR TITLE
Fix P2 Edge XMM SD service handling

### DIFF
--- a/source/lib/catalina/secread.c
+++ b/source/lib/catalina/secread.c
@@ -1,4 +1,102 @@
 #include <sd.h>
+#include <stdint.h>
+#include <prop.h>
+#ifdef __CATALINA_LARGE
+#include <hmalloc.h>
+#endif
+
+#define SD_SERVICE_TIMEOUT_SPINS 10000000u
+
+#ifdef __CATALINA_LARGE
+static char *sd_sector_read_buffer;
+static volatile long *sd_service_params;
+
+static char *sd_sector_read_buffer_get(void)
+{
+   if (sd_sector_read_buffer == 0) {
+      sd_sector_read_buffer = (char *)hub_malloc(__CATALINA_SECTOR_SIZE);
+   }
+   return sd_sector_read_buffer;
+}
+
+static volatile long *sd_service_params_get(void)
+{
+   if (sd_service_params == 0) {
+      sd_service_params = (volatile long *)hub_malloc(2 * sizeof(long));
+   }
+   return sd_service_params;
+}
+#endif
+
+static unsigned long sd_service_2_timed(long svc, long par1, long par2)
+{
+   unsigned short entry;
+   unsigned int code;
+   unsigned int cog;
+   unsigned int lock;
+   unsigned int spins;
+   int have_lock = 0;
+   volatile request_t *request;
+   volatile long *params;
+#ifndef __CATALINA_LARGE
+   static volatile long params_storage[2];
+#endif
+
+   entry = *SERVICE_POINTER(svc);
+   code = (unsigned int)(entry & 0x7fu);
+   if (code == 0) {
+      return (unsigned long)-1;
+   }
+
+   cog = ((unsigned int)entry >> 12) & 0x0fu;
+   lock = ((unsigned int)entry >> 7) & 0x1fu;
+   request = REQUEST_BLOCK(cog);
+   if (request == 0) {
+      return (unsigned long)-1;
+   }
+   if (request->request != 0) {
+      return (unsigned long)-2;
+   }
+
+   if (lock < LOCK_MAX) {
+      if (!_locktry((int)lock)) {
+         return (unsigned long)-2;
+      }
+      have_lock = 1;
+   }
+
+#ifdef __CATALINA_LARGE
+   params = sd_service_params_get();
+   if (params == 0) {
+      if (have_lock) {
+         _lockrel((int)lock);
+      }
+      return (unsigned long)-1;
+   }
+#else
+   params = params_storage;
+#endif
+   params[0] = par1;
+   params[1] = par2;
+   request->response = 0;
+   request->request = (code << 24) | ((unsigned int)(uintptr_t)params & 0x00ffffffu);
+
+   spins = SD_SERVICE_TIMEOUT_SPINS;
+   while (request->request != 0) {
+      if (--spins == 0) {
+         request->request = 0;
+         if (have_lock) {
+            _lockrel((int)lock);
+         }
+         return (unsigned long)-3;
+      }
+   }
+
+   if (have_lock) {
+      _lockrel((int)lock);
+   }
+   return (unsigned long)request->response;
+}
 
 /*
  * SD calls : read a sector
@@ -9,17 +107,22 @@ unsigned long sd_sectread(char * buffer, long sector) {
 
    int i;
    int retval;
-   char local[__CATALINA_SECTOR_SIZE];
+   char *bounce;
 
-	retval = _long_service_2(SVC_SD_READ, (long)local, sector);
+   bounce = sd_sector_read_buffer_get();
+   if (bounce == 0) {
+      return (unsigned long)-1;
+   }
+
+	retval = sd_service_2_timed(SVC_SD_READ, (long)bounce, sector);
    for (i = 0; i < __CATALINA_SECTOR_SIZE; i++) {
-      buffer[i] = local[i];
+      buffer[i] = bounce[i];
    }
    return retval;
 
 #else
 
-	return _long_service_2(SVC_SD_READ, (long) buffer, sector);
+	return sd_service_2_timed(SVC_SD_READ, (long) buffer, sector);
 
 #endif
 

--- a/source/lib/catalina/secwrite.c
+++ b/source/lib/catalina/secwrite.c
@@ -1,4 +1,102 @@
 #include <sd.h>
+#include <stdint.h>
+#include <prop.h>
+#ifdef __CATALINA_LARGE
+#include <hmalloc.h>
+#endif
+
+#define SD_SERVICE_TIMEOUT_SPINS 10000000u
+
+#ifdef __CATALINA_LARGE
+static char *sd_sector_write_buffer;
+static volatile long *sd_service_params;
+
+static char *sd_sector_write_buffer_get(void)
+{
+   if (sd_sector_write_buffer == 0) {
+      sd_sector_write_buffer = (char *)hub_malloc(__CATALINA_SECTOR_SIZE);
+   }
+   return sd_sector_write_buffer;
+}
+
+static volatile long *sd_service_params_get(void)
+{
+   if (sd_service_params == 0) {
+      sd_service_params = (volatile long *)hub_malloc(2 * sizeof(long));
+   }
+   return sd_service_params;
+}
+#endif
+
+static unsigned long sd_service_2_timed(long svc, long par1, long par2)
+{
+   unsigned short entry;
+   unsigned int code;
+   unsigned int cog;
+   unsigned int lock;
+   unsigned int spins;
+   int have_lock = 0;
+   volatile request_t *request;
+   volatile long *params;
+#ifndef __CATALINA_LARGE
+   static volatile long params_storage[2];
+#endif
+
+   entry = *SERVICE_POINTER(svc);
+   code = (unsigned int)(entry & 0x7fu);
+   if (code == 0) {
+      return (unsigned long)-1;
+   }
+
+   cog = ((unsigned int)entry >> 12) & 0x0fu;
+   lock = ((unsigned int)entry >> 7) & 0x1fu;
+   request = REQUEST_BLOCK(cog);
+   if (request == 0) {
+      return (unsigned long)-1;
+   }
+   if (request->request != 0) {
+      return (unsigned long)-2;
+   }
+
+   if (lock < LOCK_MAX) {
+      if (!_locktry((int)lock)) {
+         return (unsigned long)-2;
+      }
+      have_lock = 1;
+   }
+
+#ifdef __CATALINA_LARGE
+   params = sd_service_params_get();
+   if (params == 0) {
+      if (have_lock) {
+         _lockrel((int)lock);
+      }
+      return (unsigned long)-1;
+   }
+#else
+   params = params_storage;
+#endif
+   params[0] = par1;
+   params[1] = par2;
+   request->response = 0;
+   request->request = (code << 24) | ((unsigned int)(uintptr_t)params & 0x00ffffffu);
+
+   spins = SD_SERVICE_TIMEOUT_SPINS;
+   while (request->request != 0) {
+      if (--spins == 0) {
+         request->request = 0;
+         if (have_lock) {
+            _lockrel((int)lock);
+         }
+         return (unsigned long)-3;
+      }
+   }
+
+   if (have_lock) {
+      _lockrel((int)lock);
+   }
+   return (unsigned long)request->response;
+}
 
 /*
  * SD calls : write a sector
@@ -9,17 +107,22 @@ unsigned long sd_sectwrite(char * buffer, long sector) {
 
    int i;
    int retval;
-   char local[__CATALINA_SECTOR_SIZE];
+   char *bounce;
+
+   bounce = sd_sector_write_buffer_get();
+   if (bounce == 0) {
+      return (unsigned long)-1;
+   }
 
    for (i = 0; i < __CATALINA_SECTOR_SIZE; i++) {
-      local[i] = buffer[i];;
+      bounce[i] = buffer[i];
    }
-	retval = _long_service_2(SVC_SD_WRITE, (long)local, sector);
+	retval = sd_service_2_timed(SVC_SD_WRITE, (long)bounce, sector);
    return retval;
 
 #else
 
-	return _long_service_2(SVC_SD_WRITE, (long)buffer, sector);
+	return sd_service_2_timed(SVC_SD_WRITE, (long)buffer, sector);
 
 #endif
 

--- a/source/lib/io/dwrite.c
+++ b/source/lib/io/dwrite.c
@@ -41,7 +41,7 @@ uint32_t DFS_WriteSector(uint8_t unit, uint8_t *buffer, uint32_t sector, uint32_
 #if DOSFS_CAN_COUNT
    if (count == 1) {
       for (j = 0; j < WRITE_RETRIES; j++) {
-         if (result = sectwrite((char *)buffer, sector) == 0) {
+         if ((result = sectwrite((char *)buffer, sector)) == 0) {
             break;
          }
          else {
@@ -83,6 +83,5 @@ uint32_t DFS_WriteSector(uint8_t unit, uint8_t *buffer, uint32_t sector, uint32_
 #endif
    return result;
 }
-
 
 

--- a/target/p2/cogsd.t
+++ b/target/p2/cogsd.t
@@ -84,6 +84,21 @@ SD_Last        = 11             ' last valid command if CLOCK defined
 SD_Last        = 5              ' last valid command if CLOCK not defined
 #endif
 
+#if defined(P2_EDGE) || defined(P2_CUSTOM)
+'
+' The P2 Edge SD socket and boot flash share pins 58..61 with CLK/CS
+' swapped. Put the boot flash into deep power-down before SD card
+' initialization so SD clocks cannot make flash drive the shared DO line.
+'
+FLASH_DO       = _SD_DO
+FLASH_DI       = _SD_DI
+FLASH_CK       = _SD_CS
+FLASH_CS       = _SD_CK
+FLASH_RESET_ENABLE = $66
+FLASH_RESET_MEMORY = $99
+FLASH_DEEP_POWER_DOWN = $B9
+#endif
+
 ' SD services:
 '
 ' The command to perform is encoded in the top 8 bits of the parameter
@@ -180,7 +195,10 @@ SD_START
 .rslt     mov     .rsltptr,.rqstptr       ' set up a pointer to ...
           add     .rsltptr,#4             ' ... our result address
 
-          call    #_SDCard_Init
+#if defined(P2_EDGE) || defined(P2_CUSTOM)
+          call    #_Flash_Sleep
+#endif
+          mov     sd_initialized,#0      ' initialize on first real request
 #ifdef CLOCK
           call    #.RTC_Init
 #endif
@@ -428,23 +446,53 @@ SD_START
 '-------------------- SD Card Functions -----------------------------------------
 
 .SD_Init
-        call    #_SDcard_Init
+        call    #_SDcard_Init_Retry
+  if_z  mov     sd_initialized,#1
+  if_nz mov     sd_initialized,#0
   if_z  mov     .rslt,#0
   if_nz neg     .rslt,#1
         ret
 
 .SD_Write
+        tjnz    sd_initialized,#.SD_Write_Check_Ready
+        call    #_SDcard_Init_Retry   ' force init if startup init was not proven
+  if_z  mov     sd_initialized,#1
+  if_nz mov     sd_initialized,#0
+  if_nz jmp     #.SD_Result     ' still no - return result from card
+.SD_Write_Check_Ready
         call    #_SD_Ready      ' SD card ready?
+  if_z  jmp     #.SD_Write_Ready
+        call    #_SDcard_Init_Retry   ' no - try a fresh initialization
+  if_z  mov     sd_initialized,#1
+  if_nz mov     sd_initialized,#0
+  if_nz jmp     #.SD_Result     ' still no - return result from card
+        call    #_SD_Ready      ' SD card ready now?
   if_nz jmp     #.SD_Result     ' no - return result from card
+.SD_Write_Ready
         call    #_writeSECTOR   ' yes - write sector
         jmp     #.SD_Result     ' return result
 
 .SD_Read
+        tjnz    sd_initialized,#.SD_Read_Check_Ready
+        call    #_SDcard_Init_Retry   ' force init if startup init was not proven
+  if_z  mov     sd_initialized,#1
+  if_nz mov     sd_initialized,#0
+  if_nz jmp     #.SD_Result     ' still no - return result from card
+.SD_Read_Check_Ready
         call    #_SD_Ready      ' SD card ready?
+  if_z  jmp     #.SD_Read_Ready
+        call    #_SDcard_Init_Retry   ' no - try a fresh initialization
+  if_z  mov     sd_initialized,#1
+  if_nz mov     sd_initialized,#0
+  if_nz jmp     #.SD_Result     ' still no - return result from card
+        call    #_SD_Ready      ' SD card ready now?
   if_nz jmp     #.SD_Result     ' no - return result from card
+.SD_Read_Ready
         call    #_readSECTOR    ' yes - read sector, return result
+        jmp     #.SD_Result
 .SD_Result
   if_z  mov     .rslt,#0
+  if_nz mov     sd_initialized,#0
   if_nz mov     .rslt, reply
         call    #_sendFF
         ret                     ' return data response
@@ -457,8 +505,16 @@ SD_START
 .SD_StopIO
 ' ??? not implemented - disable SD card ??? 
         neg     .rslt,#1
-        ret 
+        ret
 
+_SDcard_Init_Retry
+                tjnz    sd_startup_wait_done,#.do_init
+                mov     sd_startup_wait_done,#1
+                mov     sd_init_retries,  #10
+.settle         waitx   ##delay1s
+                djnz    sd_init_retries,  #.settle
+.do_init        call    #_SDcard_Init
+                ret
 '------------------------------------------------------------------------------------------------
 
 CON
@@ -545,6 +601,9 @@ check_pulldn
 '+      Send >74 clocks with /CS=1 & DI=1 starting & ending with CLK=0         +
 '+-----------------------------------------------------------------------------+
 _SDcard_Init
+#if defined(P2_EDGE) || defined(P2_CUSTOM)
+                call    #_Flash_Sleep
+#endif
                 mov     _hubdata,         #$20          ' init hub data ptr=$20 
                                                         ' ie. after CLKFREQ ($14), CLKMODE ($18) & BAUDRATE ($1C)
                 'callpa  #_SD_CS,          #check_pullup ' check for pull-up on sd_cs
@@ -794,14 +853,17 @@ _writeBLOCK                                             ' CMD24: PAR=sector, 512
                 waitx   ##SD_DELAY                      ' why is this necessary???
 .waitbusy
                 call    #_recvbyte                      ' get a byte
-                cmp     reply,            #$FF      wz  ' reply=$FF=busy ?
-        if_nz   jmp     #.writedone                     ' n: done
+                cmp     reply,            #$FF      wz  ' reply=$FF=ready ?
+        if_z    jmp     #.writedone                     ' y: done
                 getct   replyR1                         '\ y: timeout ?
                 sub     replyR1,          ini_time      '|
                 cmp     replyR1,          time_out  wc  '| c if < timeout
         if_c    jmp     #.waitbusy                      '| n: try again
                 jmp     #_fail '90                      '/ y: timed out
 .writedone
+                outl    #_SD_CK                         ' CLK=0 (idle)          already=0
+                call    #_recvbyte                      ' SEND 8 CLOCKS BEFORE DISABLING CS
+                outh    #_SD_CS                         ' /CS=1 (disable)
         _RET_   MODZ    _set                            ' "Z" = success
 '+=============================================================================+
 '+-----------------------------------------------------------------------------+
@@ -890,6 +952,56 @@ _sendrecv       mov     reply,            #0            ' clear reply
         _RET_   outl    #_SD_CK                         ' CLK=0 on exit
 '+=============================================================================+
 
+#if defined(P2_EDGE) || defined(P2_CUSTOM)
+'+-----------------------------------------------------------------------------+
+'+ Put P2 Edge boot flash into deep power-down before using shared SD pins.     +
+'+-----------------------------------------------------------------------------+
+_Flash_Sleep
+                mov     dataout,          #FLASH_RESET_ENABLE
+                call    #_Flash_Command
+                mov     dataout,          #FLASH_RESET_MEMORY
+                call    #_Flash_Command
+                waitx   ##delay20ms
+                waitx   ##delay20ms
+                waitx   ##delay20ms
+                waitx   ##delay20ms
+                waitx   ##delay20ms
+                mov     dataout,          #FLASH_DEEP_POWER_DOWN
+                call    #_Flash_Command
+                waitx   ##delay5us
+                    drvh    #_SD_CS                         ' SD /CS=1 (flash CK high)
+                    drvh    #_SD_CK                         ' SD CLK=1 (flash /CS high; both chips deselected)
+                drvh    #_SD_DI                         ' SD DI=1
+        _RET_   fltl    #_SD_DO                         ' SD DO=input
+
+_Flash_Command
+                drvh    #FLASH_CS
+                drvh    #FLASH_CK
+                drvl    #FLASH_DI
+                fltl    #FLASH_DO
+                waitx   ##delay5us
+                drvl    #FLASH_CS
+                drvl    #FLASH_CK
+                call    #_Flash_SendByte
+                drvh    #FLASH_CK                         ' SD /CS=1 while flash is idle
+                drvh    #FLASH_CS
+                drvh    #FLASH_DI
+        _RET_   waitx   ##delay5us
+
+_Flash_SendByte
+                rol     dataout,          #24
+                mov     bitscnt,          #8
+.flashbit       rol     dataout,          #1        wc
+                outl    #FLASH_CK
+                outc    #FLASH_DI
+                waitx   #(2+CLOCK_EXTRA/2)
+                outh    #FLASH_CK
+                waitx   #(3+CLOCK_EXTRA/2)
+                djnz    bitscnt,          #.flashbit
+        _RET_   outl    #FLASH_CK
+'+=============================================================================+
+#endif
+
 '+-----------------------------------------------------------------------------+
 _fail           outh    #_SD_CS                         ' /CS=1 (disable)
         _RET_   MODCZ   _set,_clr                   wcz ' C & NZ = fail
@@ -915,6 +1027,9 @@ ini_time        long    0                       ' initial time
 time_out        long    0                       ' length of timeout
                                                 '\ 1=SDV1, 2=SDV2(byte address), 3=SDHC/SDV2(block address)
 blocksh         long    0                       '/ block shift 0/9 bits
+sd_initialized  long    0                       ' true after successful SD init
+sd_init_retries long    0                       ' bounded first-request init settle
+sd_startup_wait_done long 0                     ' true after first init settle window
 
 bufaddr         long    0                       ' ptr sector buffer
 blocknr         long    0                       ' sector#
@@ -939,4 +1054,3 @@ _hubdata        long    0
 |ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                         |
 +------------------------------------------------------------------------------------------------------------------------------+
 }}
-


### PR DESCRIPTION
## Summary

This PR fixes the Catalina P2 SD service path needed for P2 Edge boards where the boot flash and SD socket share pins, and for XMM/LARGE programs that access SD sectors through the Catalina service cog.

The motivating downstream case is Berry on a P2 Edge32 board: starting from a fresh Catalina checkout should be enough to build normal Edge32 and standalone XMM Berry images without carrying local Catalina patches.

## What changed

- Put the P2 Edge boot flash into deep power-down before SD initialization, with ordering that keeps the shared flash/SD pins deselected safely.
- Initialize the SD service on first real request and reinitialize when the card is no longer ready.
- Use bounded SD service waits in `sd_sectread()` and `sd_sectwrite()` so a failed SD request returns instead of wedging the caller.
- Use Hub RAM bounce buffers for `__CATALINA_LARGE` sector I/O so XMM callers do not hand unsuitable buffers to the SD service cog.
- Fix `DFS_WriteSector()` assignment precedence so retry/error handling sees the actual `sectwrite()` result.

## Why

On P2 Edge, the boot flash and SD card share pins 58..61 with clock/select crossed. After standalone XMM flash boot, the flash may still interfere with SD traffic unless it is explicitly isolated before Catalina starts SD access.

In XMM/LARGE mode, sector buffers also need to be safe for the SD service cog, and unbounded waits can make failures look like a hard runtime hang.

## Validation

Previously validated downstream with Berry using this Catalina fork on a P2 Edge32 board at `/dev/cu.usbserial-P97cvdxp`:

- `make p2-edge32-ram TOOLCHAIN=catalina CATALINA_DIR=/Users/fred/Documents/Code/catalina-speccy88 PORT=/dev/cu.usbserial-P97cvdxp`
  - Reached the Edge32 Berry REPL.
  - `p2.fs_info("/")` reported `mount_result_name='ok'`, `sd_response=0`, and `partition_start=2048`.
- `make p2-edge32-flash TOOLCHAIN=catalina CATALINA_DIR=/Users/fred/Documents/Code/catalina-speccy88 PORT=/dev/cu.usbserial-P97cvdxp`
  - Reached the Edge32 Berry REPL.
  - Berry `file`, `os`, and `os.path` SD checklist passed.
- `make p2-xmm-flash TOOLCHAIN=catalina CATALINA_DIR=/Users/fred/Documents/Code/catalina-speccy88 CATALINA_PLAIN_SD=1 PORT=/dev/cu.usbserial-P97cvdxp`
  - Reached the XMM Berry REPL.
  - `p2.fs_info("/")` reported `mount_result_name='ok'`, `sd_response=0`, `partition_start=2048`, and FAT32.
  - Berry `file`, `os`, and `os.path` SD checklist passed.

I did not rerun those hardware checks while opening this PR.