### PR TITLE
[codex] Fix P2 Edge SD service support

### DIFF
--- a/source/lib/catalina/secread.c
+++ b/source/lib/catalina/secread.c
@@ -1,4 +1,106 @@
 #include <sd.h>
+#include <stdint.h>
+#include <prop.h>
+#ifdef __CATALINA_LARGE
+#include <hmalloc.h>
+#endif
+
+volatile int berry_p2_sd_read_diag_phase;
+volatile int berry_p2_sd_read_diag_response;
+volatile int berry_p2_sd_read_diag_token;
+
+#define SD_SERVICE_TIMEOUT_SPINS 10000000u
+
+#ifdef __CATALINA_LARGE
+static char *sd_sector_read_buffer;
+static volatile long *sd_service_params;
+
+static char *sd_sector_read_buffer_get(void)
+{
+	if (sd_sector_read_buffer == 0) {
+		sd_sector_read_buffer = (char *)hub_malloc(__CATALINA_SECTOR_SIZE);
+	}
+	return sd_sector_read_buffer;
+}
+
+static volatile long *sd_service_params_get(void)
+{
+	if (sd_service_params == 0) {
+		sd_service_params = (volatile long *)hub_malloc(2 * sizeof(long));
+	}
+	return sd_service_params;
+}
+#endif
+
+static unsigned long sd_service_2_timed(long svc, long par1, long par2)
+{
+	unsigned short entry;
+	unsigned int code;
+	unsigned int cog;
+	unsigned int lock;
+	unsigned int spins;
+	int have_lock = 0;
+	volatile request_t *request;
+	volatile long *params;
+#ifndef __CATALINA_LARGE
+	static volatile long params_storage[2];
+#endif
+
+	entry = *SERVICE_POINTER(svc);
+	code = (unsigned int)(entry & 0x7fu);
+	if (code == 0) {
+		return (unsigned long)-1;
+	}
+
+	cog = ((unsigned int)entry >> 12) & 0x0fu;
+	lock = ((unsigned int)entry >> 7) & 0x1fu;
+	request = REQUEST_BLOCK(cog);
+	if (request == 0) {
+		return (unsigned long)-1;
+	}
+	if (request->request != 0) {
+		return (unsigned long)-2;
+	}
+
+	if (lock < LOCK_MAX) {
+		if (!_locktry((int)lock)) {
+			return (unsigned long)-2;
+		}
+		have_lock = 1;
+	}
+
+#ifdef __CATALINA_LARGE
+	params = sd_service_params_get();
+	if (params == 0) {
+		if (have_lock) {
+			_lockrel((int)lock);
+		}
+		return (unsigned long)-1;
+	}
+#else
+	params = params_storage;
+#endif
+	params[0] = par1;
+	params[1] = par2;
+	request->response = 0;
+	request->request = (code << 24) | ((unsigned int)(uintptr_t)params & 0x00ffffffu);
+
+	spins = SD_SERVICE_TIMEOUT_SPINS;
+	while (request->request != 0) {
+		if (--spins == 0) {
+			request->request = 0;
+			if (have_lock) {
+				_lockrel((int)lock);
+			}
+			return (unsigned long)-3;
+		}
+	}
+
+	if (have_lock) {
+		_lockrel((int)lock);
+	}
+	return (unsigned long)request->response;
+}
 
 /*
  * SD calls : read a sector
@@ -9,17 +111,30 @@ unsigned long sd_sectread(char * buffer, long sector) {
 
    int i;
    int retval;
-   char local[__CATALINA_SECTOR_SIZE];
+   char *bounce;
 
-	retval = _long_service_2(SVC_SD_READ, (long)local, sector);
+   bounce = sd_sector_read_buffer_get();
+   if (bounce == 0) {
+      return (unsigned long)-1;
+   }
+
+	berry_p2_sd_read_diag_phase = SVC_SD_READ;
+	berry_p2_sd_read_diag_token = 1;
+	retval = sd_service_2_timed(SVC_SD_READ, (long)bounce, sector);
+	berry_p2_sd_read_diag_response = retval;
+	berry_p2_sd_read_diag_token = 0;
    for (i = 0; i < __CATALINA_SECTOR_SIZE; i++) {
-      buffer[i] = local[i];
+      buffer[i] = bounce[i];
    }
    return retval;
 
 #else
 
-	return _long_service_2(SVC_SD_READ, (long) buffer, sector);
+	berry_p2_sd_read_diag_phase = SVC_SD_READ;
+	berry_p2_sd_read_diag_token = 1;
+	berry_p2_sd_read_diag_response = sd_service_2_timed(SVC_SD_READ, (long) buffer, sector);
+	berry_p2_sd_read_diag_token = 0;
+	return berry_p2_sd_read_diag_response;
 
 #endif
 

--- a/source/lib/catalina/secwrite.c
+++ b/source/lib/catalina/secwrite.c
@@ -1,4 +1,102 @@
 #include <sd.h>
+#include <stdint.h>
+#include <prop.h>
+#ifdef __CATALINA_LARGE
+#include <hmalloc.h>
+#endif
+
+#define SD_SERVICE_TIMEOUT_SPINS 10000000u
+
+#ifdef __CATALINA_LARGE
+static char *sd_sector_write_buffer;
+static volatile long *sd_service_params;
+
+static char *sd_sector_write_buffer_get(void)
+{
+   if (sd_sector_write_buffer == 0) {
+      sd_sector_write_buffer = (char *)hub_malloc(__CATALINA_SECTOR_SIZE);
+   }
+   return sd_sector_write_buffer;
+}
+
+static volatile long *sd_service_params_get(void)
+{
+   if (sd_service_params == 0) {
+      sd_service_params = (volatile long *)hub_malloc(2 * sizeof(long));
+   }
+   return sd_service_params;
+}
+#endif
+
+static unsigned long sd_service_2_timed(long svc, long par1, long par2)
+{
+   unsigned short entry;
+   unsigned int code;
+   unsigned int cog;
+   unsigned int lock;
+   unsigned int spins;
+   int have_lock = 0;
+   volatile request_t *request;
+   volatile long *params;
+#ifndef __CATALINA_LARGE
+   static volatile long params_storage[2];
+#endif
+
+   entry = *SERVICE_POINTER(svc);
+   code = (unsigned int)(entry & 0x7fu);
+   if (code == 0) {
+      return (unsigned long)-1;
+   }
+
+   cog = ((unsigned int)entry >> 12) & 0x0fu;
+   lock = ((unsigned int)entry >> 7) & 0x1fu;
+   request = REQUEST_BLOCK(cog);
+   if (request == 0) {
+      return (unsigned long)-1;
+   }
+   if (request->request != 0) {
+      return (unsigned long)-2;
+   }
+
+   if (lock < LOCK_MAX) {
+      if (!_locktry((int)lock)) {
+         return (unsigned long)-2;
+      }
+      have_lock = 1;
+   }
+
+#ifdef __CATALINA_LARGE
+   params = sd_service_params_get();
+   if (params == 0) {
+      if (have_lock) {
+         _lockrel((int)lock);
+      }
+      return (unsigned long)-1;
+   }
+#else
+   params = params_storage;
+#endif
+   params[0] = par1;
+   params[1] = par2;
+   request->response = 0;
+   request->request = (code << 24) | ((unsigned int)(uintptr_t)params & 0x00ffffffu);
+
+   spins = SD_SERVICE_TIMEOUT_SPINS;
+   while (request->request != 0) {
+      if (--spins == 0) {
+         request->request = 0;
+         if (have_lock) {
+            _lockrel((int)lock);
+         }
+         return (unsigned long)-3;
+      }
+   }
+
+   if (have_lock) {
+      _lockrel((int)lock);
+   }
+   return (unsigned long)request->response;
+}
 
 /*
  * SD calls : write a sector
@@ -9,17 +107,22 @@ unsigned long sd_sectwrite(char * buffer, long sector) {
 
    int i;
    int retval;
-   char local[__CATALINA_SECTOR_SIZE];
+   char *bounce;
+
+   bounce = sd_sector_write_buffer_get();
+   if (bounce == 0) {
+      return (unsigned long)-1;
+   }
 
    for (i = 0; i < __CATALINA_SECTOR_SIZE; i++) {
-      local[i] = buffer[i];;
+      bounce[i] = buffer[i];
    }
-	retval = _long_service_2(SVC_SD_WRITE, (long)local, sector);
+	retval = sd_service_2_timed(SVC_SD_WRITE, (long)bounce, sector);
    return retval;
 
 #else
 
-	return _long_service_2(SVC_SD_WRITE, (long)buffer, sector);
+	return sd_service_2_timed(SVC_SD_WRITE, (long)buffer, sector);
 
 #endif
 

--- a/source/lib/io/dwrite.c
+++ b/source/lib/io/dwrite.c
@@ -41,7 +41,7 @@ uint32_t DFS_WriteSector(uint8_t unit, uint8_t *buffer, uint32_t sector, uint32_
 #if DOSFS_CAN_COUNT
    if (count == 1) {
       for (j = 0; j < WRITE_RETRIES; j++) {
-         if (result = sectwrite((char *)buffer, sector) == 0) {
+         if ((result = sectwrite((char *)buffer, sector)) == 0) {
             break;
          }
          else {
@@ -83,6 +83,5 @@ uint32_t DFS_WriteSector(uint8_t unit, uint8_t *buffer, uint32_t sector, uint32_
 #endif
    return result;
 }
-
 
 

--- a/target/p2/cogsd.t
+++ b/target/p2/cogsd.t
@@ -84,13 +84,28 @@ SD_Last        = 11             ' last valid command if CLOCK defined
 SD_Last        = 5              ' last valid command if CLOCK not defined
 #endif
 
+#if defined(P2_EDGE) || defined(P2_CUSTOM)
+'
+' The P2 Edge SD socket and boot flash share pins 58..61 with CLK/CS
+' swapped. Put the boot flash into deep power-down before SD card
+' initialization so SD clocks cannot make flash drive the shared DO line.
+'
+FLASH_DO       = _SD_DO
+FLASH_DI       = _SD_DI
+FLASH_CK       = _SD_CS
+FLASH_CS       = _SD_CK
+FLASH_RESET_ENABLE = $66
+FLASH_RESET_MEMORY = $99
+FLASH_DEEP_POWER_DOWN = $B9
+#endif
+
 ' SD services:
 '
 ' The command to perform is encoded in the top 8 bits of the parameter
 ' The address of a parameter block is encoded in the bottom 24 bits.
 ' The parameter block is 2 longs:
 '    - the buffer adress to use
-'    - the sector number to read/write 
+'    - the sector number to read/write
 
 'name: SD_Init - Initialize the driver
 'code: 1
@@ -105,19 +120,19 @@ SD_Last        = 5              ' last valid command if CLOCK not defined
 'rslt: (none)
 '
 'name: SD_Write - Write a sector
-'code: 3 
+'code: 3
 'type: long request
 'data: parameter block address
 'rslt: 0 on success, data response token on failure (with bit 8 set to ensure not zero!)
-   
+
 'name: SD_ByteIO - Write a sector
-'code: 4 
+'code: 4
 'type: short request
 'data: byte to write
 'rslt: 0 on success, data response token on failure (with bit 8 set to ensure not zero!)
 
 'name: SD_StopIO - disable the SD card (required on the TRIBLADEPROP and RAMBLADE)
-'code: 5 
+'code: 5
 'type: short request
 'data: byte to write
 'rslt: (none)
@@ -154,7 +169,7 @@ SD_Last        = 5              ' last valid command if CLOCK not defined
 'type: long request
 'data: 0 = no debug, 1 = toggle debug flag every second
 'rslt: none
-   
+
 'name: SD_RTC_GetTicks (new time function also implemented in SD plugin)
 'code: 11
 'type: short request
@@ -180,12 +195,15 @@ SD_START
 .rslt     mov     .rsltptr,.rqstptr       ' set up a pointer to ...
           add     .rsltptr,#4             ' ... our result address
 
-          call    #_SDCard_Init
+#if defined(P2_EDGE) || defined(P2_CUSTOM)
+          call    #_Flash_Sleep
+#endif
+          mov     sd_initialized,#0      ' initialize on first real request
 #ifdef CLOCK
           call    #.RTC_Init
 #endif
 
-.pause 
+.pause
         waitx   ##delay5us
 
 #ifdef CLOCK
@@ -209,7 +227,7 @@ SD_START
         mov     .rslt, #0
         sub     .t1,#SD_First
         shl     .t1,#1
-        add     .t1,#.cmdTable 
+        add     .t1,#.cmdTable
         jmp     .t1                      ' jump to command
 
 .cmdTable
@@ -242,7 +260,7 @@ SD_START
         neg     .rslt,#1                 ' return -1 on error
         jmp     #.end_command
 .end_command
-        wrlong  .rslt,.rsltptr           ' return .rslt 
+        wrlong  .rslt,.rsltptr           ' return .rslt
         wrlong  Zeroval,.rqstptr         ' clear command status
         jmp     #.pause                  ' pause before next command
 
@@ -261,17 +279,17 @@ SD_START
 '
 ' RTC_Update : update the clock and time counters
 '
-.RTC_Update                        
+.RTC_Update
         tjnz    .per_sec,#.got_freq     ' no - if frequency not set ...
         call    #.RTC_Init              ' .. just re-initialize
         ret                             ' done
 .got_freq
         getct   .t3                     ' get latest cnt
         cmp     .t3,.clock_cnt_last wcz ' compare with last cnt used for clock
-  if_ae jmp     #.clock_no_wrap         ' check for wrap                 
+  if_ae jmp     #.clock_no_wrap         ' check for wrap
         mov     .t2,.clock_cnt_last     ' calculate increment ...
         sub     .t2,.t3                 ' ... when wrap has occurred
-        jmp     #.update_clock                        
+        jmp     #.update_clock
 .clock_no_wrap
         mov     .t2,.t3                 ' calculate increment ...
         sub     .t2,.clock_cnt_last     ' ... when no wrap has occurred
@@ -288,10 +306,10 @@ SD_START
         mov     .clock_incr,.t1         ' ... save remainder for next round
 .do_time
         cmp     .t3,.time_cnt_last wcz  ' compare with last cnt used for clock
-  if_ae jmp     #.time_no_wrap          ' check for wrap                 
+  if_ae jmp     #.time_no_wrap          ' check for wrap
         mov     .t2,.time_cnt_last      ' calculate increment ...
         sub     .t2,.t3                 ' ... when wrap has occurred
-        jmp     #.update_time                        
+        jmp     #.update_time
 .time_no_wrap
         mov     .t2,.t3                 ' calculate increment ...
         sub     .t2,.time_cnt_last      ' ... when no wrap has occurred
@@ -308,14 +326,14 @@ SD_START
         mov     .time_incr,.t1          ' ... save remainder for next round
         tjz     .debug_flag,#.update_done ' if not debug, done
         cmp     .t0,#0 wz               ' did we increment time?
-#ifdef SD_DEBUG_LED_CLOCK                        
+#ifdef SD_DEBUG_LED_CLOCK
         drvnot  #SD_DEBUG_LED           ' toggle SD_DEBUG_LED
 #endif
 .update_done
         ret
 
 '
-' RTC_SetFreq : Set the frequency, calculate counts per clock tick, 
+' RTC_SetFreq : Set the frequency, calculate counts per clock tick,
 '               and reset the clock counters
 '
 .RTC_SetFreq
@@ -364,7 +382,7 @@ SD_START
    _ret_ mov     .debug_flag,.param
 
 '
-' RTC_GetTicks : return current time, as 2 longs, 
+' RTC_GetTicks : return current time, as 2 longs,
 '              result = 0 if frequency has been set, -1 otherwise
 '
 .RTC_GetTicks
@@ -412,10 +430,10 @@ SD_START
 
 .clock_res       long    SD_CLOCKS_PER_SEC       ' clock resolution (fixed at compile time)
 
-.per_sec         long    0                       ' cnts per sec (system clock frequency)                 
+.per_sec         long    0                       ' cnts per sec (system clock frequency)
 .per_clock       long    0                       ' cnts per clock
 
-.clock           long    0                       ' current clock val                       
+.clock           long    0                       ' current clock val
 .clock_cnt_last  long    0                       ' last cnt value retrieved
 .clock_incr      long    0                       ' count as yet unprocessed
 
@@ -428,23 +446,53 @@ SD_START
 '-------------------- SD Card Functions -----------------------------------------
 
 .SD_Init
-        call    #_SDcard_Init
+        call    #_SDcard_Init_Retry
+  if_z  mov     sd_initialized,#1
+  if_nz mov     sd_initialized,#0
   if_z  mov     .rslt,#0
   if_nz neg     .rslt,#1
         ret
 
 .SD_Write
+        tjnz    sd_initialized,#.SD_Write_Check_Ready
+        call    #_SDcard_Init_Retry   ' force init if startup init was not proven
+  if_z  mov     sd_initialized,#1
+  if_nz mov     sd_initialized,#0
+  if_nz jmp     #.SD_Result     ' still no - return result from card
+.SD_Write_Check_Ready
         call    #_SD_Ready      ' SD card ready?
+  if_z  jmp     #.SD_Write_Ready
+        call    #_SDcard_Init_Retry   ' no - try a fresh initialization
+  if_z  mov     sd_initialized,#1
+  if_nz mov     sd_initialized,#0
+  if_nz jmp     #.SD_Result     ' still no - return result from card
+        call    #_SD_Ready      ' SD card ready now?
   if_nz jmp     #.SD_Result     ' no - return result from card
+.SD_Write_Ready
         call    #_writeSECTOR   ' yes - write sector
         jmp     #.SD_Result     ' return result
 
 .SD_Read
+        tjnz    sd_initialized,#.SD_Read_Check_Ready
+        call    #_SDcard_Init_Retry   ' force init if startup init was not proven
+  if_z  mov     sd_initialized,#1
+  if_nz mov     sd_initialized,#0
+  if_nz jmp     #.SD_Result     ' still no - return result from card
+.SD_Read_Check_Ready
         call    #_SD_Ready      ' SD card ready?
+  if_z  jmp     #.SD_Read_Ready
+        call    #_SDcard_Init_Retry   ' no - try a fresh initialization
+  if_z  mov     sd_initialized,#1
+  if_nz mov     sd_initialized,#0
+  if_nz jmp     #.SD_Result     ' still no - return result from card
+        call    #_SD_Ready      ' SD card ready now?
   if_nz jmp     #.SD_Result     ' no - return result from card
+.SD_Read_Ready
         call    #_readSECTOR    ' yes - read sector, return result
+        jmp     #.SD_Result
 .SD_Result
   if_z  mov     .rslt,#0
+  if_nz mov     sd_initialized,#0
   if_nz mov     .rslt, reply
         call    #_sendFF
         ret                     ' return data response
@@ -455,9 +503,18 @@ SD_START
         ret
 
 .SD_StopIO
-' ??? not implemented - disable SD card ??? 
+' ??? not implemented - disable SD card ???
         neg     .rslt,#1
-        ret 
+        ret
+
+_SDcard_Init_Retry
+                tjnz    sd_startup_wait_done,#.do_init
+                mov     sd_startup_wait_done,#1
+                mov     sd_init_retries,  #10
+.settle         waitx   ##delay1s
+                djnz    sd_init_retries,  #.settle
+.do_init        call    #_SDcard_Init
+                ret
 
 '------------------------------------------------------------------------------------------------
 
@@ -545,7 +602,10 @@ check_pulldn
 '+      Send >74 clocks with /CS=1 & DI=1 starting & ending with CLK=0         +
 '+-----------------------------------------------------------------------------+
 _SDcard_Init
-                mov     _hubdata,         #$20          ' init hub data ptr=$20 
+#if defined(P2_EDGE) || defined(P2_CUSTOM)
+                call    #_Flash_Sleep
+#endif
+                mov     _hubdata,         #$20          ' init hub data ptr=$20
                                                         ' ie. after CLKFREQ ($14), CLKMODE ($18) & BAUDRATE ($1C)
                 'callpa  #_SD_CS,          #check_pullup ' check for pull-up on sd_cs
         'if_nc   jmp     #_fail '_pullup                 '
@@ -584,7 +644,7 @@ _SDcard_Init
 '+ _SD_Ready: check SD card is ready (send $FF until $FF received)             +
 '+            return Z if ok, NZ and reply on timeout                          +
 '+-----------------------------------------------------------------------------+
-_SD_Ready       getct   ini_time                        '\ set timeout 
+_SD_Ready       getct   ini_time                        '\ set timeout
                 mov     time_out,         ##delay1s     '/
                 outl    #_SD_CS                         ' /CS=0 (enable)
 .again1         call    #_recvbyte                      ' read data byte
@@ -784,7 +844,7 @@ _writeBLOCK                                             ' CMD24: PAR=sector, 512
                 call    #_sendFF                        ' CRC16 byte 1/2
                 call    #_sendFF                        ' CRC16 byte 2/2
                 waitx   ##SD_DELAY                      ' why is this necessary???
-                call    #_getreply                      ' 
+                call    #_getreply                      '
                 and     reply,            #$1f
                 cmp     reply,            #$5 wz
        if_z     jmp     #.waitdelay
@@ -794,14 +854,17 @@ _writeBLOCK                                             ' CMD24: PAR=sector, 512
                 waitx   ##SD_DELAY                      ' why is this necessary???
 .waitbusy
                 call    #_recvbyte                      ' get a byte
-                cmp     reply,            #$FF      wz  ' reply=$FF=busy ?
-        if_nz   jmp     #.writedone                     ' n: done
+                cmp     reply,            #$FF      wz  ' reply=$FF=ready ?
+        if_z    jmp     #.writedone                     ' y: done
                 getct   replyR1                         '\ y: timeout ?
                 sub     replyR1,          ini_time      '|
                 cmp     replyR1,          time_out  wc  '| c if < timeout
         if_c    jmp     #.waitbusy                      '| n: try again
                 jmp     #_fail '90                      '/ y: timed out
 .writedone
+                outl    #_SD_CK                         ' CLK=0 (idle)          already=0
+                call    #_recvbyte                      ' SEND 8 CLOCKS BEFORE DISABLING CS
+                outh    #_SD_CS                         ' /CS=1 (disable)
         _RET_   MODZ    _set                            ' "Z" = success
 '+=============================================================================+
 '+-----------------------------------------------------------------------------+
@@ -890,6 +953,56 @@ _sendrecv       mov     reply,            #0            ' clear reply
         _RET_   outl    #_SD_CK                         ' CLK=0 on exit
 '+=============================================================================+
 
+#if defined(P2_EDGE) || defined(P2_CUSTOM)
+'+-----------------------------------------------------------------------------+
+'+ Put P2 Edge boot flash into deep power-down before using shared SD pins.     +
+'+-----------------------------------------------------------------------------+
+_Flash_Sleep
+                mov     dataout,          #FLASH_RESET_ENABLE
+                call    #_Flash_Command
+                mov     dataout,          #FLASH_RESET_MEMORY
+                call    #_Flash_Command
+                waitx   ##delay20ms
+                waitx   ##delay20ms
+                waitx   ##delay20ms
+                waitx   ##delay20ms
+                waitx   ##delay20ms
+                mov     dataout,          #FLASH_DEEP_POWER_DOWN
+                call    #_Flash_Command
+                waitx   ##delay5us
+                    drvh    #_SD_CS                         ' SD /CS=1 (flash CK high)
+                    drvh    #_SD_CK                         ' SD CLK=1 (flash /CS high; both chips deselected)
+                drvh    #_SD_DI                         ' SD DI=1
+        _RET_   fltl    #_SD_DO                         ' SD DO=input
+
+_Flash_Command
+                drvh    #FLASH_CS
+                drvh    #FLASH_CK
+                drvl    #FLASH_DI
+                fltl    #FLASH_DO
+                waitx   ##delay5us
+                drvl    #FLASH_CS
+                drvl    #FLASH_CK
+                call    #_Flash_SendByte
+                drvh    #FLASH_CK                         ' SD /CS=1 while flash is idle
+                drvh    #FLASH_CS
+                drvh    #FLASH_DI
+        _RET_   waitx   ##delay5us
+
+_Flash_SendByte
+                rol     dataout,          #24
+                mov     bitscnt,          #8
+.flashbit       rol     dataout,          #1        wc
+                outl    #FLASH_CK
+                outc    #FLASH_DI
+                waitx   #(2+CLOCK_EXTRA/2)
+                outh    #FLASH_CK
+                waitx   #(3+CLOCK_EXTRA/2)
+                djnz    bitscnt,          #.flashbit
+        _RET_   outl    #FLASH_CK
+'+=============================================================================+
+#endif
+
 '+-----------------------------------------------------------------------------+
 _fail           outh    #_SD_CS                         ' /CS=1 (disable)
         _RET_   MODCZ   _set,_clr                   wcz ' C & NZ = fail
@@ -915,6 +1028,9 @@ ini_time        long    0                       ' initial time
 time_out        long    0                       ' length of timeout
                                                 '\ 1=SDV1, 2=SDV2(byte address), 3=SDHC/SDV2(block address)
 blocksh         long    0                       '/ block shift 0/9 bits
+sd_initialized  long    0                       ' true after successful SD init
+sd_init_retries long    0                       ' bounded first-request init settle
+sd_startup_wait_done long 0                     ' true after first init settle window
 
 bufaddr         long    0                       ' ptr sector buffer
 blocknr         long    0                       ' sector#
@@ -939,4 +1055,3 @@ _hubdata        long    0
 |ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                         |
 +------------------------------------------------------------------------------------------------------------------------------+
 }}
-


### PR DESCRIPTION
## What changed

- Make the P2 SD cog service more robust for P2 Edge-style shared flash/SD wiring by putting boot flash into deep power-down before SD initialization and retrying/lazily initializing SD on the first real request.
- Replace raw `_long_service_2()` sector calls with a bounded SD service helper so failed or wedged requests return an error instead of spinning forever.
- Keep LARGE-model sector bounce buffers in hub memory, avoiding sector buffers/parameter blocks that the SD service cog cannot safely access.
- Fix the `DFS_WriteSector()` assignment/compare precedence bug so retry handling sees the real `sectwrite()` result.

## Why

Downstream Berry P2 Edge32 bring-up exposed SD hangs and failed module imports when starting from a fresh Catalina build. The practical failure was that sector service helpers could be generated for the wrong memory assumptions, and the P2 Edge SD/flash shared pins needed explicit bus isolation before SD traffic.

With this in Catalina, a fresh compiler/runtime build has the SD service behavior needed by the Berry P2 Edge direct-SD path instead of relying on a local post-build patch.

## Validation

- Not re-run in this clean PR worktree.
- Extracted from the patched Catalina tree used during Berry P2 Edge32 SD/import bring-up, where `p2.fs_info("/")` reached a valid FAT volume at sector 2048 and `import math; print(math.sqrt(81))` was used as the downstream module-import check.
